### PR TITLE
Update to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>net.jaxonbrown.guardianBeam</groupId>
     <artifactId>GuardianBeamAPI</artifactId>
     <packaging>jar</packaging>
-    <version>1.2</version>
+    <version>1.3</version>
     <name>GuardianBeamAPI</name>
     <url>https://github.com/MeRPG/GuardianBeamAPI</url>
     <properties>
@@ -45,17 +45,16 @@
             <artifactId>lombok</artifactId>
             <version>1.16.6</version>
         </dependency>
-
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>com.comphenix.protocol</groupId>
-            <artifactId>ProtocolLib-API</artifactId>
-            <version>4.3.0</version>
-        </dependency>
+	  	<dependency>
+	    	<groupId>com.comphenix.protocol</groupId>
+	    	<artifactId>ProtocolLib</artifactId>
+	    	<version>4.8.0</version>
+	  	</dependency>
     </dependencies>
 
     <repositories>
@@ -65,7 +64,7 @@
         </repository>
         <repository>
             <id>dmulloy2-repo</id>
-            <url>http://repo.dmulloy2.net/nexus/repository/public/</url>
+            <url>https://repo.dmulloy2.net/repository/public/</url>
         </repository>
     </repositories>
 </project>

--- a/src/main/java/net/jaxonbrown/guardianBeam/protocol/AbstractPacket.java
+++ b/src/main/java/net/jaxonbrown/guardianBeam/protocol/AbstractPacket.java
@@ -1,0 +1,116 @@
+package net.jaxonbrown.guardianBeam.protocol;
+
+/**
+ * PacketWrapper - ProtocolLib wrappers for Minecraft packets
+ * Copyright (C) dmulloy2 <http://dmulloy2.net>
+ * Copyright (C) Kristian S. Strangeland
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.bukkit.entity.Player;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketContainer;
+import com.google.common.base.Objects;
+
+public abstract class AbstractPacket {
+	// The packet we will be modifying
+	protected PacketContainer handle;
+
+	/**
+	 * Constructs a new strongly typed wrapper for the given packet.
+	 * 
+	 * @param handle - handle to the raw packet data.
+	 * @param type - the packet type.
+	 */
+	protected AbstractPacket(PacketContainer handle, PacketType type) {
+		// Make sure we're given a valid packet
+		if (handle == null)
+			throw new IllegalArgumentException("Packet handle cannot be NULL.");
+		if (!Objects.equal(handle.getType(), type))
+			throw new IllegalArgumentException(handle.getHandle()
+					+ " is not a packet of type " + type);
+
+		this.handle = handle;
+	}
+
+	/**
+	 * Retrieve a handle to the raw packet data.
+	 * 
+	 * @return Raw packet data.
+	 */
+	public PacketContainer getHandle() {
+		return handle;
+	}
+
+	/**
+	 * Send the current packet to the given receiver.
+	 * 
+	 * @param receiver - the receiver.
+	 * @throws RuntimeException If the packet cannot be sent.
+	 */
+	public void sendPacket(Player receiver) {
+		try {
+			ProtocolLibrary.getProtocolManager().sendServerPacket(receiver,
+					getHandle());
+		} catch (InvocationTargetException e) {
+			throw new RuntimeException("Cannot send packet.", e);
+		}
+	}
+
+	/**
+	 * Send the current packet to all online players.
+	 */
+	public void broadcastPacket() {
+		ProtocolLibrary.getProtocolManager().broadcastServerPacket(getHandle());
+	}
+
+	/**
+	 * Simulate receiving the current packet from the given sender.
+	 * 
+	 * @param sender - the sender.
+	 * @throws RuntimeException If the packet cannot be received.
+	 * @deprecated Misspelled. recieve to receive
+	 * @see #receivePacket(Player)
+	 */
+	@Deprecated
+	public void recievePacket(Player sender) {
+		try {
+			ProtocolLibrary.getProtocolManager().recieveClientPacket(sender,
+					getHandle());
+		} catch (Exception e) {
+			throw new RuntimeException("Cannot recieve packet.", e);
+		}
+	}
+
+	/**
+	 * Simulate receiving the current packet from the given sender.
+	 * 
+	 * @param sender - the sender.
+	 * @throws RuntimeException if the packet cannot be received.
+	 */
+	public void receivePacket(Player sender) {
+		try {
+			ProtocolLibrary.getProtocolManager().recieveClientPacket(sender,
+					getHandle());
+		} catch (Exception e) {
+			throw new RuntimeException("Cannot receive packet.", e);
+		}
+	}
+
+}

--- a/src/main/java/net/jaxonbrown/guardianBeam/protocol/PacketFactory.java
+++ b/src/main/java/net/jaxonbrown/guardianBeam/protocol/PacketFactory.java
@@ -17,16 +17,22 @@
  */
 package net.jaxonbrown.guardianBeam.protocol;
 
-import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.reflect.accessors.Accessors;
-import com.comphenix.protocol.utility.MinecraftReflection;
-import com.comphenix.protocol.wrappers.WrappedDataWatcher;
-import org.bukkit.Location;
-import org.bukkit.entity.Entity;
-
 import java.util.UUID;
 
-import static com.comphenix.protocol.PacketType.Play.Server.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.injector.BukkitUnwrapper;
+import com.comphenix.protocol.reflect.accessors.Accessors;
+import com.comphenix.protocol.utility.MinecraftReflection;
+import com.comphenix.protocol.wrappers.BukkitConverters;
+import com.comphenix.protocol.wrappers.WrappedDataWatcher;
+import com.comphenix.protocol.wrappers.WrappedDataWatcher.Registry;
+import com.google.common.collect.Lists;
 
 /**
  * The PacketFactory generates and modifies the packets for the library to use.
@@ -34,132 +40,112 @@ import static com.comphenix.protocol.PacketType.Play.Server.*;
  * @author Jaxon A Brown
  */
 public class PacketFactory {
-    private static Entity fakeSquid;
-    private static Entity fakeGuardian;
 
-    /**
-     * Generate fake entities
-     */
-    static {
-        fakeSquid = (Entity) Accessors.getConstructorAccessor(
-                MinecraftReflection.getCraftBukkitClass("entity.CraftSquid"),
-                MinecraftReflection.getCraftBukkitClass("CraftServer"),
-                MinecraftReflection.getMinecraftClass("EntitySquid")
-        ).invoke(null, Accessors.getConstructorAccessor(
-                MinecraftReflection.getMinecraftClass("EntitySquid"),
-                MinecraftReflection.getNmsWorldClass()
-            ).invoke(new Object[] {null}));
+	private static Entity fakeSquid;
+	private static Entity fakeGuardian;
 
-        fakeGuardian = (Entity) Accessors.getConstructorAccessor(
-                MinecraftReflection.getCraftBukkitClass("entity.CraftGuardian"),
-                MinecraftReflection.getCraftBukkitClass("CraftServer"),
-                MinecraftReflection.getMinecraftClass("EntityGuardian")
-        ).invoke(null, Accessors.getConstructorAccessor(
-                MinecraftReflection.getMinecraftClass("EntityGuardian"),
-                MinecraftReflection.getNmsWorldClass()
-            ).invoke(new Object[] {null}));
-    }
+	static {
+		fakeSquid = (Entity) Accessors.getConstructorAccessor(
+				MinecraftReflection.getCraftBukkitClass("entity.CraftSquid"),
+				MinecraftReflection.getCraftBukkitClass("CraftServer"),
+				MinecraftReflection.getMinecraftClass("world.entity.animal.EntitySquid")
+		).invoke(Bukkit.getServer(), Accessors.getConstructorAccessor(
+				MinecraftReflection.getMinecraftClass("world.entity.animal.EntitySquid"),
+				MinecraftReflection.getMinecraftClass("world.entity.EntityTypes"),
+				MinecraftReflection.getNmsWorldClass()
+		).invoke(new Object[] {BukkitConverters.getEntityTypeConverter().getGeneric(EntityType.SQUID),
+				BukkitUnwrapper.getInstance().unwrapItem(Bukkit.getWorlds().get(0))}));
 
-    /**
-     * Creates a packet to spawn a squid at the location.
-     * @param location location to spawn the squid.
-     * @return beam packet used to spawn for players.
-     */
-    public static WrappedBeamPacket createPacketSquidSpawn(Location location) {
-        PacketContainer container = new PacketContainer(SPAWN_ENTITY_LIVING);
-        container.getIntegers().write(0, EIDGen.generateEID());
-        container.getUUIDs().write(0, UUID.randomUUID());
-        container.getIntegers().write(1, 94);
-        container.getDoubles().write(0, location.getX());
-        container.getDoubles().write(1, location.getY());
-        container.getDoubles().write(2, location.getZ());
-        container.getBytes().write(0, (byte) (location.getYaw() * 256.0F / 360.0F));
-        container.getBytes().write(1, (byte) (location.getPitch() * 256.0F / 360.0F));
-        WrappedDataWatcher wrapper = WrappedDataWatcher.getEntityWatcher(fakeSquid);
-        wrapper.setObject(0, (byte) 32);
-        container.getDataWatcherModifier().write(0, wrapper);
-        return new WrappedBeamPacket(container);
-    }
+		fakeGuardian = (Entity) Accessors.getConstructorAccessor(
+				MinecraftReflection.getCraftBukkitClass("entity.CraftGuardian"),
+				MinecraftReflection.getCraftBukkitClass("CraftServer"),
+				MinecraftReflection.getMinecraftClass("world.entity.monster.EntityGuardian")
+		).invoke(Bukkit.getServer(), Accessors.getConstructorAccessor(
+				MinecraftReflection.getMinecraftClass("world.entity.monster.EntityGuardian"),
+				MinecraftReflection.getMinecraftClass("world.entity.EntityTypes"),
+				MinecraftReflection.getNmsWorldClass()
+				).invoke(new Object[] {BukkitConverters.getEntityTypeConverter().getGeneric(EntityType.GUARDIAN),
+						BukkitUnwrapper.getInstance().unwrapItem(Bukkit.getWorlds().get(0))}));
+	}
 
-    /**
-     * Creates a packet to spawn a guardian at the location.
-     * @param location location to spawn the guardian.
-     * @param squidPacket squid the guardian will target.
-     * @return beam packet used to spawn for players.
-     */
-    public static WrappedBeamPacket createPacketGuardianSpawn(Location location, WrappedBeamPacket squidPacket) {
-        PacketContainer container = new PacketContainer(SPAWN_ENTITY_LIVING);
-        container.getIntegers().write(0, EIDGen.generateEID());
-        container.getUUIDs().write(0, UUID.randomUUID());
-        container.getIntegers().write(1, 68);
-        container.getDoubles().write(0, location.getX());
-        container.getDoubles().write(1, location.getY());
-        container.getDoubles().write(2, location.getZ());
-        container.getBytes().write(0, (byte) (location.getYaw() * 256.0F / 360.0F));
-        container.getBytes().write(1, (byte) (location.getPitch() * 256.0F / 360.0F));
-        WrappedDataWatcher watcher = WrappedDataWatcher.getEntityWatcher(fakeGuardian);
-        watcher.setObject(0, (byte) 32);
-        watcher.setObject(12, false);
-        watcher.setObject(13, squidPacket.getHandle().getIntegers().read(0));
-        container.getDataWatcherModifier().write(0, watcher);
-        return new WrappedBeamPacket(container);
-    }
+	public static WrappedBeamPacket createPacketSquidSpawn(Location location) {
+		PacketContainer container = new PacketContainer(PacketType.Play.Server.SPAWN_ENTITY);
+		int entityID = EIDGen.generateEID();
+		container.getIntegers().write(0, entityID);
+		container.getUUIDs().write(0, UUID.randomUUID());
+		container.getEntityTypeModifier().write(0, EntityType.SQUID);
+		container.getDoubles().write(0, location.getX());
+		container.getDoubles().write(1, location.getY());
+		container.getDoubles().write(2, location.getZ());
+		container.getBytes().write(0, (byte) (location.getYaw() * 256.0F / 360.0F));
+		container.getBytes().write(1, (byte) (location.getPitch() * 256.0F / 360.0F));
 
-    /**
-     * Modifies location information of the given Spawn Packet.
-     * @param entitySpawnPacket SquidSpawn or GuardianSpawn packet for the entity.
-     * @param location location the entity should be spawned at.
-     * @return beam packet used to spawn for players.
-     */
-    public static WrappedBeamPacket modifyPacketEntitySpawn(WrappedBeamPacket entitySpawnPacket, Location location) {
-        PacketContainer container = entitySpawnPacket.getHandle();
-        container.getIntegers().write(2, (int) Math.floor(location.getX() * 32.0));
-        container.getIntegers().write(3, (int) Math.floor(location.getY() * 32.0));
-        container.getIntegers().write(4, (int) Math.floor(location.getZ() * 32.0));
-        container.getBytes().write(0, (byte) (location.getYaw() * 256.0F / 360.0F));
-        container.getBytes().write(1, (byte) (location.getPitch() * 256.0F / 360.0F));
-        return entitySpawnPacket;
-    }
+		WrapperPlayServerEntityMetadata wrapper = new WrapperPlayServerEntityMetadata();
+		WrappedDataWatcher watcher = WrappedDataWatcher.getEntityWatcher(fakeSquid);
+		// Invisible
+		watcher.setObject(0, Registry.get(Byte.class), (byte) 0x20);
+		wrapper.setMetadata(watcher.getWatchableObjects());
+		wrapper.setEntityID(entityID);
+		return new WrappedBeamPacket(container, wrapper);
+	}
 
-    /**
-     * Creates a packet to move an entity. Doesn't include where to move it to.
-     * @param entityPacket SquidSpawn or GuardianSpawn packet for the entity.
-     * @return Skeleton packet for the given entity.
-     */
-    public static WrappedBeamPacket createPacketEntityMove(WrappedBeamPacket entityPacket) {
-        PacketContainer container = new PacketContainer(ENTITY_TELEPORT);
-        container.getIntegers().write(0, entityPacket.getHandle().getIntegers().read(0));
-        return new WrappedBeamPacket(container);
-    }
+	public static WrappedBeamPacket createPacketGuardianSpawn(Location location, WrappedBeamPacket squidPacket) {
+		PacketContainer container = new PacketContainer(PacketType.Play.Server.SPAWN_ENTITY);
+		int entityID = EIDGen.generateEID();
+		container.getIntegers().write(0, entityID);
+		container.getUUIDs().write(0, UUID.randomUUID());
+		container.getEntityTypeModifier().write(0, EntityType.GUARDIAN);
+		container.getDoubles().write(0, location.getX());
+		container.getDoubles().write(1, location.getY());
+		container.getDoubles().write(2, location.getZ());
+		container.getBytes().write(0, (byte) (location.getYaw() * 256.0F / 360.0F));
+		container.getBytes().write(1, (byte) (location.getPitch() * 256.0F / 360.0F));
 
-    /**
-     * Adds location information to a packet to move an entity.
-     * @param entityMovePacket EntityMove packet to add location information to.
-     * @param location location to move the entity to.
-     * @return Finished packet to teleport the given entity.
-     */
-    public static WrappedBeamPacket modifyPacketEntityMove(WrappedBeamPacket entityMovePacket, Location location) {
-        PacketContainer container = entityMovePacket.getHandle();
-        container.getIntegers().write(1, (int) Math.floor(location.getX() * 32.0D));
-        container.getIntegers().write(2, (int) Math.floor(location.getY() * 32.0D));
-        container.getIntegers().write(3, (int) Math.floor(location.getZ() * 32.0D));
-        container.getBytes().write(0, (byte) (location.getYaw() * 256.0F / 360.0F));
-        container.getBytes().write(1, (byte) (location.getPitch() * 256.0F / 360.0F));
-        return entityMovePacket;
-    }
+		WrapperPlayServerEntityMetadata wrapper = new WrapperPlayServerEntityMetadata();
+		WrappedDataWatcher watcher = WrappedDataWatcher.getEntityWatcher(fakeGuardian);
+		// Invisible
+		watcher.setObject(0, Registry.get(Byte.class), (byte) 0x20);
+		// Is retracting spikes
+		watcher.setObject(16, false);
+		// Target EID
+		watcher.setObject(17, squidPacket.getHandle().getIntegers().read(0));
+		wrapper.setMetadata(watcher.getWatchableObjects());
+		wrapper.setEntityID(entityID);
+		return new WrappedBeamPacket(container, wrapper);
+	}
 
-    /**
-     * Creates a packet to remove the guardian and squid entities.
-     * @param squidPacket SquidSpawn of the entity to remove
-     * @param guardianPacket GuardianSpawn of the entity to remove
-     * @return Packet to remove the guardian and squid when sent to a player.
-     */
-    public static WrappedBeamPacket createPacketRemoveEntities(WrappedBeamPacket squidPacket, WrappedBeamPacket guardianPacket) {
-        PacketContainer container = new PacketContainer(ENTITY_DESTROY);
-        container.getIntegerArrays().write(0, new int[] {
-                squidPacket.getHandle().getIntegers().read(0),
-                guardianPacket.getHandle().getIntegers().read(0)
-        });
-        return new WrappedBeamPacket(container);
-    }
+	public static WrappedBeamPacket modifyPacketEntitySpawn(WrappedBeamPacket entitySpawnPacket, Location location) {
+		PacketContainer container = entitySpawnPacket.getHandle();
+		container.getIntegers().write(2, (int) Math.floor(location.getX() * 32.0));
+		container.getIntegers().write(3, (int) Math.floor(location.getY() * 32.0));
+		container.getIntegers().write(4, (int) Math.floor(location.getZ() * 32.0));
+		container.getBytes().write(0, (byte) (location.getYaw() * 256.0F / 360.0F));
+		container.getBytes().write(1, (byte) (location.getPitch() * 256.0F / 360.0F));
+		return entitySpawnPacket;
+	}
+
+	public static WrappedBeamPacket createPacketEntityMove(WrappedBeamPacket entityPacket) {
+		PacketContainer container = new PacketContainer(PacketType.Play.Server.ENTITY_TELEPORT);
+		container.getIntegers().write(0, entityPacket.getHandle().getIntegers().read(0));
+		return new WrappedBeamPacket(container);
+	}
+
+	public static WrappedBeamPacket modifyPacketEntityMove(WrappedBeamPacket entityMovePacket, Location location) {
+		PacketContainer container = entityMovePacket.getHandle();
+		container.getIntegers().write(1, (int) Math.floor(location.getX() * 32.0D));
+		container.getIntegers().write(2, (int) Math.floor(location.getY() * 32.0D));
+		container.getIntegers().write(3, (int) Math.floor(location.getZ() * 32.0D));
+		container.getBytes().write(0, (byte) (location.getYaw() * 256.0F / 360.0F));
+		container.getBytes().write(1, (byte) (location.getPitch() * 256.0F / 360.0F));
+		return entityMovePacket;
+	}
+
+	public static WrappedBeamPacket createPacketRemoveEntities(WrappedBeamPacket squidPacket, WrappedBeamPacket guardianPacket) {
+		PacketContainer container = new PacketContainer(PacketType.Play.Server.ENTITY_DESTROY);
+		container.getIntLists().write(0, Lists.newArrayList(
+				squidPacket.getHandle().getIntegers().read(0),
+				guardianPacket.getHandle().getIntegers().read(0)));
+		return new WrappedBeamPacket(container);
+	}
+
 }

--- a/src/main/java/net/jaxonbrown/guardianBeam/protocol/WrappedBeamPacket.java
+++ b/src/main/java/net/jaxonbrown/guardianBeam/protocol/WrappedBeamPacket.java
@@ -28,33 +28,43 @@ import java.lang.reflect.InvocationTargetException;
  * @author Jaxon A Brown
  */
 public class WrappedBeamPacket {
-    private final PacketContainer handle;
 
-    /**
-     * Wraps the packet.
-     * @param container packet to wrap.
-     */
-    public WrappedBeamPacket(PacketContainer container) {
-        this.handle = container;
-    }
+	private final WrapperPlayServerEntityMetadata metadata;
+	private final PacketContainer handle;
 
-    /**
-     * Sends the packet to a lucky receiver!
-     * @param receiver player to send the packet to.
-     */
-    public void send(Player receiver) {
-        try {
-            ProtocolLibrary.getProtocolManager().sendServerPacket(receiver, this.handle);
-        } catch(InvocationTargetException ex) {
-            throw new RuntimeException("Failed to send beam packet to player.", ex);
-        }
-    }
+	/**
+	 * Wraps the packet.
+	 * @param container packet to wrap.
+	 */
+	public WrappedBeamPacket(PacketContainer container) {
+		this(container, null);
+	}
 
-    /**
-     * Get the packet container.
-     * @return ProtocolLib packet container.
-     */
-    public PacketContainer getHandle() {
-        return this.handle;
-    }
+	public WrappedBeamPacket(PacketContainer container, WrapperPlayServerEntityMetadata metadata) {
+		this.metadata = metadata;
+		this.handle = container;
+	}
+
+	/**
+	 * Sends the packet to a lucky receiver!
+	 * @param receiver player to send the packet to.
+	 */
+	public void send(Player receiver) {
+		try {
+			ProtocolLibrary.getProtocolManager().sendServerPacket(receiver, this.handle);
+			if (metadata != null)
+				metadata.sendPacket(receiver);
+		} catch(InvocationTargetException ex) {
+			throw new RuntimeException("Failed to send beam packet to player.", ex);
+		}
+	}
+
+	/**
+	 * Get the packet container.
+	 * @return ProtocolLib packet container.
+	 */
+	public PacketContainer getHandle() {
+		return this.handle;
+	}
+
 }

--- a/src/main/java/net/jaxonbrown/guardianBeam/protocol/WrapperPlayServerEntityMetadata.java
+++ b/src/main/java/net/jaxonbrown/guardianBeam/protocol/WrapperPlayServerEntityMetadata.java
@@ -1,0 +1,103 @@
+package net.jaxonbrown.guardianBeam.protocol;
+
+/**
+ * PacketWrapper - ProtocolLib wrappers for Minecraft packets
+ * Copyright (C) dmulloy2 <http://dmulloy2.net>
+ * Copyright (C) Kristian S. Strangeland
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import java.util.List;
+
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedWatchableObject;
+
+public class WrapperPlayServerEntityMetadata extends AbstractPacket {
+
+	public static final PacketType TYPE = PacketType.Play.Server.ENTITY_METADATA;
+
+	public WrapperPlayServerEntityMetadata() {
+		super(new PacketContainer(TYPE), TYPE);
+		handle.getModifier().writeDefaults();
+	}
+
+	public WrapperPlayServerEntityMetadata(PacketContainer packet) {
+		super(packet, TYPE);
+	}
+
+	/**
+	 * Retrieve Entity ID.
+	 * <p>
+	 * Notes: entity's ID
+	 * 
+	 * @return The current Entity ID
+	 */
+	public int getEntityID() {
+		return handle.getIntegers().read(0);
+	}
+
+	/**
+	 * Set Entity ID.
+	 * 
+	 * @param value - new value.
+	 */
+	public void setEntityID(int value) {
+		handle.getIntegers().write(0, value);
+	}
+
+	/**
+	 * Retrieve the entity of the painting that will be spawned.
+	 * 
+	 * @param world - the current world of the entity.
+	 * @return The spawned entity.
+	 */
+	public Entity getEntity(World world) {
+		return handle.getEntityModifier(world).read(0);
+	}
+
+	/**
+	 * Retrieve the entity.
+	 * 
+	 * @param event - the packet event.
+	 * @return The spawned entity.
+	 */
+	public Entity getEntity(PacketEvent event) {
+		return getEntity(event.getPlayer().getWorld());
+	}
+
+	/**
+	 * Retrieve Metadata.
+	 * 
+	 * @return The current Metadata
+	 */
+	public List<WrappedWatchableObject> getMetadata() {
+		return handle.getWatchableCollectionModifier().read(0);
+	}
+
+	/**
+	 * Set Metadata.
+	 * 
+	 * @param value - new value.
+	 */
+	public void setMetadata(List<WrappedWatchableObject> value) {
+		handle.getWatchableCollectionModifier().write(0, value);
+	}
+
+}


### PR DESCRIPTION
- Updates Spigot and PacketFactory to 1.19
- Changes ProtocolLib location to match the newer url and https.
- Bump version to 1.3.

So in 1.19 Mojang moved the entity data to it's own packet rather than being included in the spawn packet, so we need to send two packets to the client to simulate the guardian beam.

Might also work on versions 1.15+, untested and I didn't do protocol research on those versions. Mojang changed the entity data packet to be separate from the spawn packet in 1.14